### PR TITLE
Opt in to perf-report, compress perf.data

### DIFF
--- a/kerneltools-start
+++ b/kerneltools-start
@@ -8,6 +8,9 @@ echo "pwd: `/bin/pwd`"
 echo
 echo "hostname: `hostname`"
 echo
+echo "mount:"
+mount
+echo
 # defaults
 subtools="perf"
 
@@ -47,7 +50,9 @@ for subtool in `echo $subtools | sed -e 's/,/ /g'`; do
     case "$subtool" in
         perf)
             echo "Starting perf record"
-            TZ=UTC S_TIME_FORMAT=ISO /usr/bin/perf record -a $perf_record_opts &
+            mkdir -p ~/.debug
+            echo going to run "/usr/bin/perf record -a $perf_record_opts"
+            /usr/bin/perf record -a $perf_record_opts &
             perf_pid=$!
             echo "perf pid is $perf_pid"
             echo "$perf_pid" >>kerneltools-pids.txt

--- a/kerneltools-stop
+++ b/kerneltools-stop
@@ -11,8 +11,9 @@ echo
 
 # defaults
 subtools="perf"
+perf_gen_local_report=0
 
-longopts="subtools,perf-record-opts:"
+longopts="subtools,perf-record-opts:,perf-gen-local-report"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     printf -- "\tUnrecognized option specified\n\n"
@@ -32,6 +33,10 @@ while true; do
             record_opts=$1
             echo "perf_record_opts=$perf_record_opts"
             shift;
+            ;;
+        --perf-gen-local-report)
+            shift;
+            perf_gen_local_report=1
             ;;
         --)
             shift;
@@ -68,6 +73,10 @@ for subtool in `echo $subtools | sed -e 's/,/ /g'`; do
         perf)
             echo "Running perf archive"
             time /usr/bin/perf archive perf.data
+            if [ "$perf_gen_local_report" == "1" ]; then
+                perf report 2>&1 >perf-report.txt
+            fi
+            xz --threads=0 perf.data
             ;;
         *)
             echo "Invalid subtool: $subtool"

--- a/workshop.json
+++ b/workshop.json
@@ -10,6 +10,7 @@
             "requirements": [
                 "diffutils",
                 "bzip2_src",
+                "xz_src",
                 "bison_src",
                 "flex_src",
                 "perf_src"
@@ -36,6 +37,23 @@
                     "unpack": "tar -zxf bzip2-1.0.6.tar.gz",
                     "get_dir": "tar -ztf bzip2-1.0.6.tar.gz | head -n 1 | awk -F/ '{print $1}'",
                     "commands": [
+                        "make",
+                        "make install"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "xz_src",
+            "type": "source",
+            "source_info": {
+                "url": "https://tukaani.org/xz/xz-5.2.5.tar.gz",
+                "filename": "xz-5.2.5.tar.gz",
+                "commands": {
+                    "unpack": "tar -zxf xz-5.2.5.tar.gz",
+                    "get_dir": "tar -ztf xz-5.2.5.tar.gz | head -n 1",
+                    "commands": [
+                        "./configure",
                         "make",
                         "make install"
                     ]
@@ -77,14 +95,14 @@
             }
         },
         {
-            "name": "perf",
+            "name": "perf_src",
             "type": "source",
             "source_info": {
-                "url": "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.7.tar.xz",
-                "filename": "linux-5.7.tar.xz",
+                "url": "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.7.tar.gz",
+                "filename": "linux-5.7.tar.gz",
                 "commands": {
-                    "unpack": "tar -Jxf linux-5.7.tar.xz",
-                    "get_dir": "tar -Jtf linux-5.7.tar.xz | head -n 1",
+                    "unpack": "tar -zxf linux-5.7.tar.gz",
+                    "get_dir": "tar -ztf linux-5.7.tar.gz | head -n 1",
                     "commands": [
                         "make -C tools/ perf_install prefix=/usr/",
                         "rm -rf *"


### PR DESCRIPTION
-default behavior is to do a 'perf-archive' which saves
 enough info to generate a perf report on another system
 later.
-xz is used to compress because it can do multi-threaded
 compression which is much faster.