### PR TITLE
add --date to the 'trace-cmd record' command

### DIFF
--- a/kerneltools-start
+++ b/kerneltools-start
@@ -139,7 +139,7 @@ for subtool in `echo $subtools | sed -e 's/,/ /g'`; do
             echo "Available trace-cmd tracers:"
             /usr/local/bin/trace-cmd list -t
             echo "Starting function trace with functions: $trace_cmd_functions"
-            cmd="/usr/local/bin/trace-cmd record"
+            cmd="/usr/local/bin/trace-cmd record --date"
             cmd+=" $trace_cmd_record_opts"
             echo "Going to run:"
             echo "$cmd"


### PR DESCRIPTION
- From the man page:

  With the --date option, "trace-cmd" will write timestamps into the
  trace buffer after it has finished recording. It will then map the
  timestamp to gettimeofday which will allow wall time output from the
  timestamps reading the created trace.dat file.