### PR TITLE
Fix bison/gettext builds

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -40,7 +40,7 @@
                     "unpack": "tar -xf bison.tar.xz",
                     "get_dir": "tar -tf bison.tar.xz | head -n 1",
                     "commands": [
-                        "./configure",
+                        "./configure gl_cv_func_getcwd_path_max='yes, but with shorter paths'",
                         "make -j32 install",
                         "ldconfig",
                         "rm -rf *"
@@ -58,7 +58,7 @@
                     "unpack": "tar -xf gettext.tar.xz",
                     "get_dir": "tar -tf gettext.tar.xz | head -n 1",
                     "commands": [
-                        "./configure",
+                        "./configure gl_cv_func_getcwd_path_max='yes, but with shorter paths'",
                         "make -j32 install",
                         "ldconfig",
                         "rm -rf *"


### PR DESCRIPTION
bison and gettext have a conftest that checks getcwd when length > 4k, which results in a deep dir created that cannot be removed in some enviroments. This makes CI jobs fail with:

confdir3/.../confdir3: file name too long

This patch overcomes this issue by creating shorter paths with the following configure arg:

gl_cv_func_getcwd_path_max="yes, but with shorter paths"