### PR TITLE
Install binaries for kernel tools

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -8,21 +8,23 @@
         {
             "name": "default",
             "requirements": [
-		"packages",
-                "bzip2_src",
-		"bison_src",
-		"gettext_src",
-		"flex_src",
-		"libtraceevent_src",
-		"libtracefs_src",
-		"tracecmd_src",
-		"tools_src"
+		"packages"
             ]
         }
     ],
     "requirements": [
         {
             "name": "packages",
+            "type": "distro",
+            "distro_info": {
+                "packages": [
+		    "kernel-tools",
+		    "perf"
+		]
+            }
+        },
+        {
+            "name": "src-dependencies",
             "type": "distro",
             "distro_info": {
                 "packages": [


### PR DESCRIPTION
Stop building from sources, support fedora userenv Keep the sources in workshop.json for reference (unused)