### PR TITLE
fix: turbostat filename mismatch, missing post-process, and other bugs

### DIFF
--- a/boot_to_epoch.py
+++ b/boot_to_epoch.py
@@ -5,24 +5,24 @@ import sys
 def main(args):
     '''
     We need to be able select a time range inside of a perf report.
-    We have the time range in milliseconds since the unix epoc
-    we need the offsect in seconds.nanoseconds since the boot of the system
-    these are the conversions. The variable names are meant to inidicate
+    We have the time range in milliseconds since the unix epoch
+    we need the offset in seconds.nanoseconds since the boot of the system
+    these are the conversions. The variable names are meant to indicate
     the unit of time and source of stamp.
     '''
 
     # convert seconds to milliseconds
-    boot_msec_epoc = args.boot_time * 1_000
+    boot_msec_epoch = args.boot_time * 1_000
 
     # Convert first sample to milliseconds
     perf_first_sample_msec = args.perf_first_sample * 1_000
 
     # time of first recording in epoch milliseconds
-    perf_first_sample_msec_epoc = boot_msec_epoc + perf_first_sample_msec
+    perf_first_sample_msec_epoch = boot_msec_epoch + perf_first_sample_msec
 
     # how many milliseconds into the perf recording is my sample
-    crucible_sample_start_msec_offset = args.crucible_sample_start - perf_first_sample_msec_epoc
-    crucible_sample_stop_msec_offset = args.crucible_sample_stop - perf_first_sample_msec_epoc
+    crucible_sample_start_msec_offset = args.crucible_sample_start - perf_first_sample_msec_epoch
+    crucible_sample_stop_msec_offset = args.crucible_sample_stop - perf_first_sample_msec_epoch
 
     # Convert msec offset to seconds.nanoseconds (but we won't have nanosecond precision)
     crucible_sample_start_sec_nsec = crucible_sample_start_msec_offset / 1_000
@@ -32,14 +32,14 @@ def main(args):
     final_start_sec_nsec = args.perf_first_sample + crucible_sample_start_sec_nsec
     final_stop_sec_nsec = args.perf_first_sample + crucible_sample_stop_sec_nsec
 
-    print(f"perf report --time {format(final_start_sec_nsec,'.6g')},{format(final_stop_sec_nsec, '.6g')}")
+    print(f"perf report --time {format(final_start_sec_nsec,'.6f')},{format(final_stop_sec_nsec, '.6f')}")
     sys.exit(0)
 
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(
-            description = 'Create harmony between crucible epoc time and perf time')
+            description = 'Create harmony between crucible epoch time and perf time')
 
     parser.add_argument('-b','--sys-boot-time',
             type = int, required = True, dest = 'boot_time',
@@ -51,11 +51,11 @@ if __name__ == '__main__':
                     use perf report --header-only to get this value')
     parser.add_argument('-s1','--sample-start',
             type = int, required = True, dest = 'crucible_sample_start',
-            help = 'the start time in milliseconds since epoc of the desired\
+            help = 'the start time in milliseconds since epoch of the desired\
                     sample as reported by crucible')
     parser.add_argument('-s2','--sample-stop',
             type = int, required = True, dest = 'crucible_sample_stop',
-            help = 'the stop time in milliseconds since epoc of the desired\
+            help = 'the stop time in milliseconds since epoch of the desired\
                     sample as reported by crucible')
     args = parser.parse_args()
     main(args)

--- a/kerneltools-start
+++ b/kerneltools-start
@@ -66,7 +66,7 @@ while true; do
             ;;
         --interval)
             interval=$val
-            echo "setting turbo_freq=$turbo_freq"
+            echo "setting interval=$interval"
             ;;
         --trace-cmd-record-opts)
             trace_cmd_record_opts=$val
@@ -148,7 +148,7 @@ for subtool in `echo $subtools | sed -e 's/,/ /g'`; do
             echo "Starting trace-cmd"
             echo "Available trace-cmd tracers:"
             /usr/local/bin/trace-cmd list -t
-            echo "Starting function trace with functions: $trace_cmd_functions"
+            echo "Starting trace-cmd with record opts: $trace_cmd_record_opts"
             cmd="/usr/local/bin/trace-cmd record --date"
             cmd+=" $trace_cmd_record_opts"
             echo "Going to run:"

--- a/kerneltools-stop
+++ b/kerneltools-stop
@@ -126,11 +126,11 @@ for subtool in `echo $subtools | sed -e 's/,/ /g'`; do
             ${taskset_cmd} xz --threads=0 perf.data
             ;;
         turbostat)
-            if [ -e turbostat-out.txt ]; then
+            if [ -e turbostat-stdout.txt ]; then
                 echo "Compressing turbostat output"
-                ${taskset_cmd} xz --threads=0 turbostat-out.txt
+                ${taskset_cmd} xz --threads=0 turbostat-stdout.txt
             else
-                echo "Warning: turbostat-out.txt was not found"
+                echo "Warning: turbostat-stdout.txt was not found"
             fi
             ;;
         trace-cmd)

--- a/rickshaw.json
+++ b/rickshaw.json
@@ -5,9 +5,6 @@
         }
     },
     "tool": "kernel",
-    "controller": {
-        "post-script": "%tool-dir%kerneltools-post-process"
-    },
     "collector": {
         "files-from-controller": [
             {


### PR DESCRIPTION
## Summary

- **Turbostat data never archived**: `kerneltools-start` writes to `turbostat-stdout.txt` but `kerneltools-stop` looks for `turbostat-out.txt`. Fixed filename in stop script to match.
- **Non-existent post-process script**: `rickshaw.json` referenced `kerneltools-post-process` which doesn't exist. Removed the controller block.
- **Copy-paste in --interval handler**: Echo printed `turbo_freq` instead of `interval`.
- **Undefined $trace_cmd_functions**: Log message referenced a variable that was never set. Changed to use `$trace_cmd_record_opts`.
- **Scientific notation in boot_to_epoch.py**: `.6g` format switches to scientific notation on long-uptime systems, breaking `perf report --time` parsing. Changed to `.6f` for fixed-point.
- **Typos**: `epoc` → `epoch` (5x), `offsect` → `offset`, `inidicate` → `indicate`.

## Jira

- [PERFNFV-383](https://redhat.atlassian.net/browse/PERFNFV-383)

## Test plan

- [x] `bash -n` passes on both shell scripts
- [x] `python3 -m py_compile` passes on boot_to_epoch.py
- [x] `jq .` validates rickshaw.json
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)